### PR TITLE
Improve performance of entropy calculation

### DIFF
--- a/entropy.py
+++ b/entropy.py
@@ -9,6 +9,7 @@ __description__ = 'Calculate Shannon Entropy for given file'
 
 import sys
 import math
+from collections import Counter
 
 def main():
     entropy()
@@ -16,27 +17,25 @@ def main():
 def entropy():
     print('Opening file {}...'.format(sys.argv[1]))
     with open(sys.argv[1], 'rb') as f:
-        byteArr = list(f.read())
+        byteArr = f.read()
+
     fileSize = len(byteArr)
-    print
+    print("")
     print('File size in bytes: {:,d}'.format(fileSize))
+
     # calculate the frequency of each byte value in the file
     print('Calculating Shannon entropy of file. Please wait...')
-    freqList = []
-    for b in range(256):
-        ctr = 0
-        for byte in byteArr:
-            if byte == b:
-                ctr += 1
-        freqList.append(float(ctr) / fileSize)
+    counts = Counter(byteArr)
+    freqList =  [byteCount / fileSize for byteCount in dict(counts).values()]
+
     # Shannon entropy
     ent = 0.0
     for freq in freqList:
-        if freq > 0:
-            ent = ent + freq * math.log(freq, 2)
+        ent = ent + freq * math.log(freq, 2)
     ent = -ent
+    
     print('Shannon entropy: {}'.format(ent))
-    print
+    print("")
 
 
 if __name__== "__main__":


### PR DESCRIPTION
This repo is the 4th google result for searches like "python calculate entropy of file" and the 1st github repo. It is unfortunately slow. The currently implementation scans the file 256 times to check each byte value. This is not necessary if we keep track of the byte as we see them.  This could be done with a `dict`, however I have chosen to use `collections.Counter` which is a subclass of `dict`.

I have also removed unnecessary casts and restructured one of the for loops as a list comprehension, this avoids calls to `list().append()` and uses special opcodes to loop faster.